### PR TITLE
문서 릴리즈 버전 표시 방식 개선

### DIFF
--- a/.github/docs-deploy.yml
+++ b/.github/docs-deploy.yml
@@ -14,6 +14,7 @@ release:
   timezone: Asia/Seoul
   version_prefix: 4.0-Diplo
   timestamp_format: "%Y%m%d-%H%M%S"
+  prune_version_pattern: "^4\\.0-Diplo-[0-9]{8}-[0-9]{6}$"
   aliases:
     - latest
   default: latest

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -78,6 +78,7 @@ jobs:
         if: steps.config.outputs.strict == 'true'
         env:
           DOCS_RELEASE_VERSION: ${{ steps.config.outputs.release_version }}
+          DOCS_RELEASE_ID: ${{ steps.config.outputs.release_id }}
           DOCS_RELEASE_BUILT_AT: ${{ steps.config.outputs.release_built_at }}
           DOCS_RELEASE_COMMIT: ${{ steps.config.outputs.release_commit }}
         run: mkdocs build --strict --clean --site-dir /tmp/ablestack-docs-strict
@@ -95,6 +96,7 @@ jobs:
           MIKE_DEFAULT: ${{ steps.config.outputs.default }}
           MIKE_BRANCH: ${{ steps.config.outputs.branch }}
           DOCS_RELEASE_VERSION: ${{ steps.config.outputs.release_version }}
+          DOCS_RELEASE_ID: ${{ steps.config.outputs.release_id }}
           DOCS_RELEASE_BUILT_AT: ${{ steps.config.outputs.release_built_at }}
           DOCS_RELEASE_COMMIT: ${{ steps.config.outputs.release_commit }}
         run: |
@@ -127,6 +129,10 @@ jobs:
           else
             git worktree add public "${{ steps.config.outputs.branch }}"
           fi
+
+      - name: Prune timestamped release versions from deploy payload
+        if: steps.config.outputs.prune_version_pattern != ''
+        run: python scripts/prune_docs_release_versions.py public '${{ steps.config.outputs.prune_version_pattern }}'
 
       - name: Build nginx image
         id: image

--- a/README.md
+++ b/README.md
@@ -110,17 +110,17 @@ mike set-default latest
 
 `codex/**` 브랜치에서는 운영 반영을 수행하지 않습니다. 이 모드에서는 `mike` 산출물을 로컬 브랜치로 생성해 Docker 이미지까지 검증하고, 운영 서버 SSH/rsync 단계는 건너뜁니다. 기능 브랜치에서 workflow 자체를 먼저 안전하게 확인하기 위한 모드입니다.
 
-PR이 병합되어 `master` 브랜치에 push되면 자동 release mode가 적용됩니다. 이때 `mike.version` 기본값을 그대로 쓰지 않고 `release` 설정을 기준으로 `4.0-Diplo-YYYYMMDD-HHmmss` 형식의 새 version을 생성합니다. 시간대는 `Asia/Seoul` 기준입니다.
+PR이 병합되어 `master` 브랜치에 push되면 자동 release mode가 적용됩니다. 이때 `mike.version`은 `.github/docs-deploy.yml`의 `mike.version` 값(`4.0 Diplo`)을 그대로 사용합니다. 따라서 상단 버전 선택기와 운영 서버 버전 디렉터리는 날짜/시간이 붙지 않은 `4.0 Diplo` 기준으로 유지되고, 같은 version이 이미 있으면 새 빌드 결과로 덮어씁니다.
 
-예를 들어 2026년 7월 7일 14시 30분 15초에 병합된 경우 다음 version이 생성됩니다.
+날짜/시간이 필요한 릴리즈 식별자는 `mike.version`과 분리해 `release.id`로 생성합니다. 예를 들어 2026년 7월 7일 14시 30분 15초에 병합된 경우 다음 release id가 생성됩니다.
 
 ```text
 4.0-Diplo-20260707-143015
 ```
 
-자동 release mode에서는 이 version을 `latest` alias로 배포하고 `latest`를 기본 alias로 설정합니다. 또한 `release.dry_run: false` 설정을 사용하므로 `DOCS_DEPLOY_PASSWORD` Secret이 준비되어 있으면 운영 nginx 서버까지 자동 동기화합니다.
+자동 release mode에서는 `4.0 Diplo` version을 `latest` alias로 배포하고 `latest`를 기본 alias로 설정합니다. 기존 날짜형 release version 디렉터리는 배포 payload에서 제거하므로 운영 서버에 `4.0-Diplo-YYYYMMDD-HHmmss` 디렉터리가 계속 누적되지 않습니다. 또한 `release.dry_run: false` 설정을 사용하므로 `DOCS_DEPLOY_PASSWORD` Secret이 준비되어 있으면 운영 nginx 서버까지 자동 동기화합니다.
 
-release version, 빌드 일시, commit 정보는 workflow에서 `DOCS_RELEASE_VERSION`, `DOCS_RELEASE_BUILT_AT`, `DOCS_RELEASE_COMMIT` 환경변수로 MkDocs에 전달됩니다. `mkdocs.yml`은 이 값을 `extra.release`로 주입하고, 시작 페이지(`docs/index.md`)는 해당 값을 사용해 문서 릴리즈 정보를 표시합니다.
+release version, release id, 빌드 일시, commit 정보는 workflow에서 `DOCS_RELEASE_VERSION`, `DOCS_RELEASE_ID`, `DOCS_RELEASE_BUILT_AT`, `DOCS_RELEASE_COMMIT` 환경변수로 MkDocs에 전달됩니다. `mkdocs.yml`은 이 값을 `extra.release`로 주입합니다. 시작 페이지(`docs/index.md`)에는 날짜형 release id 대신 version, 빌드 일시, commit만 표시하고, release id는 이미지/artifact 식별에 사용합니다.
 
 운영 서버 접속 비밀번호는 GitHub Secrets로만 관리합니다. 비밀번호, API key, SSH key 등 민감한 값은 저장소 파일에 기록하지 않습니다.
 
@@ -149,6 +149,7 @@ release:
   timezone: Asia/Seoul
   version_prefix: 4.0-Diplo
   timestamp_format: "%Y%m%d-%H%M%S"
+  prune_version_pattern: "^4\\.0-Diplo-[0-9]{8}-[0-9]{6}$"
   aliases:
     - latest
   default: latest
@@ -176,7 +177,7 @@ verify:
 
 GitHub Actions는 `mike`로 생성한 `gh-pages` 산출물을 그대로 포함하는 nginx Docker 이미지를 함께 생성합니다. 이 이미지는 Python, MkDocs, `mike` 없이 컨테이너 실행만으로 문서 사이트를 제공합니다.
 
-이미지 산출물 기본값은 `.github/docs-deploy.yml`의 `image` 섹션에서 관리합니다. 기본 이미지 이름은 `ablestack-docs-nginx`이며, 실제 `mike.version` 값을 Docker tag로 변환한 태그와 `latest` 태그를 함께 생성합니다. 예를 들어 자동 release version `4.0-Diplo-20260707-143015`는 같은 이름의 Docker tag로 사용됩니다. GitHub Actions 환경에서는 commit 추적을 위해 `sha-<short-sha>` tag도 함께 생성합니다.
+이미지 산출물 기본값은 `.github/docs-deploy.yml`의 `image` 섹션에서 관리합니다. 기본 이미지 이름은 `ablestack-docs-nginx`이며, release mode에서는 `release.id` 값을 Docker tag로 변환한 태그와 `latest` 태그를 함께 생성합니다. 예를 들어 자동 release id `4.0-Diplo-20260707-143015`는 같은 이름의 Docker tag로 사용됩니다. GitHub Actions 환경에서는 commit 추적을 위해 `sha-<short-sha>` tag도 함께 생성합니다.
 
 컨테이너 이미지는 `docker/nginx/Dockerfile`과 `docker/nginx/default.conf`를 사용합니다. 이미지에는 `mike` 산출물 전체가 `/usr/share/nginx/html/`로 복사되며, `latest` alias는 컨테이너 안에서 바로 서비스되도록 실제 디렉터리로 풀어 복사합니다.
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -121,6 +121,7 @@ extra:
     provider: mike
   release:
     version: !ENV [DOCS_RELEASE_VERSION, "local"]
+    id: !ENV [DOCS_RELEASE_ID, "local"]
     built_at: !ENV [DOCS_RELEASE_BUILT_AT, "local build"]
     commit: !ENV [DOCS_RELEASE_COMMIT, "local"]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ mkdocs-glightbox==0.5.2
 mkdocs-macros-plugin==1.5.0
 mkdocs-exporter==6.2.0
 PyYAML==6.0.3
+tzdata==2026.2

--- a/scripts/prune_docs_release_versions.py
+++ b/scripts/prune_docs_release_versions.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+"""Prune generated timestamp release versions from a built mike site."""
+
+from __future__ import annotations
+
+import json
+import re
+import shutil
+import sys
+from pathlib import Path
+
+
+def fail(message: str) -> None:
+    raise SystemExit(f"error: {message}")
+
+
+def contained_path(root: Path, child_name: str) -> Path:
+    child = (root / child_name).resolve()
+    try:
+        child.relative_to(root)
+    except ValueError:
+        fail(f"refusing to remove path outside site root: {child_name}")
+    return child
+
+
+def main() -> None:
+    if len(sys.argv) != 3:
+        fail("usage: prune_docs_release_versions.py <site-dir> <version-regex>")
+
+    site_dir = Path(sys.argv[1]).resolve()
+    pattern = re.compile(sys.argv[2])
+    versions_path = site_dir / "versions.json"
+
+    if not site_dir.is_dir():
+        fail(f"site directory not found: {site_dir}")
+    if not versions_path.is_file():
+        print("versions.json not found; nothing to prune")
+        return
+
+    versions = json.loads(versions_path.read_text(encoding="utf-8-sig"))
+    if not isinstance(versions, list):
+        fail("versions.json must contain a list")
+
+    kept = []
+    pruned = []
+    for entry in versions:
+        version = str(entry.get("version", "")) if isinstance(entry, dict) else ""
+        if pattern.fullmatch(version):
+            pruned.append(version)
+            continue
+        kept.append(entry)
+
+    for version in pruned:
+        version_dir = contained_path(site_dir, version)
+        if version_dir.exists():
+            if version_dir.is_dir():
+                shutil.rmtree(version_dir)
+            else:
+                version_dir.unlink()
+            print(f"pruned version directory: {version}")
+        else:
+            print(f"version directory already absent: {version}")
+
+    if pruned:
+        versions_path.write_text(
+            json.dumps(kept, ensure_ascii=False, indent=2) + "\n",
+            encoding="utf-8",
+        )
+        print(f"pruned versions.json entries: {', '.join(pruned)}")
+    else:
+        print("no timestamp release versions matched prune pattern")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/resolve_docs_deploy_config.py
+++ b/scripts/resolve_docs_deploy_config.py
@@ -114,9 +114,9 @@ def main():
     aliases = shlex.split(aliases_input) if aliases_input else mike.get("aliases", [])
     default = env_override("INPUT_MIKE_DEFAULT") or mike.get("default")
     built_at = release_datetime(release)
+    release_id = release_version(release, built_at) if use_release else version
 
     if use_release:
-        version = release_version(release, built_at)
         aliases = release.get("aliases", aliases)
         default = release.get("default", default)
 
@@ -141,7 +141,8 @@ def main():
     if image_enabled and not image_name:
         raise ValueError("image.name is required when image.enabled is true")
 
-    image_tags = [docker_tag(version)]
+    primary_image_tag = release_id if use_release else version
+    image_tags = [docker_tag(primary_image_tag)]
     image_tags.extend(docker_tag(alias) for alias in image_tag_aliases)
     github_sha = os.environ.get("GITHUB_SHA", "").strip()
     github_sha_short = github_sha[:7] if github_sha else ""
@@ -162,8 +163,10 @@ def main():
         "dry_run": str(dry_run).lower(),
         "release": str(use_release).lower(),
         "release_version": version,
+        "release_id": release_id,
         "release_built_at": display_datetime(built_at),
         "release_commit": github_sha_short,
+        "prune_version_pattern": str(release.get("prune_version_pattern") or ""),
         "image_enabled": str(image_enabled).lower(),
         "image_name": image_name,
         "image_tags_json": json.dumps(unique_values(image_tags), ensure_ascii=False),


### PR DESCRIPTION
## 개요

문서 릴리즈 자동화에서 `mike` version과 날짜형 릴리즈 식별자를 분리했습니다.

기존에는 PR 병합 후 자동 릴리즈 빌드가 `4.0-Diplo-YYYYMMDD-HHmmss` 값을 `mike` version으로 사용해, 문서 상단 버전 선택기에 날짜까지 표시되고 운영 서버에도 날짜형 version 디렉터리가 계속 누적될 수 있었습니다.

이번 변경에서는 `mike` version을 `4.0 Diplo`로 유지하고, 날짜형 값은 `release.id`로만 생성해 본문 빌드 정보와 컨테이너 이미지/artifact 식별에 사용하도록 정리했습니다.

## 변경 내용

- 자동 release mode에서도 `mike.version`은 `4.0 Diplo` 값을 유지하도록 수정
- `release_id` 출력을 추가해 `4.0-Diplo-YYYYMMDD-HHmmss` 형식의 릴리즈 식별자를 별도 관리
- Docker image tag는 release mode에서 `release_id`를 사용하도록 유지
- 배포 payload에서 기존 날짜형 version 디렉터리와 `versions.json` 항목을 정리하는 pruning 스크립트 추가
- workflow에 pruning 단계를 추가해 운영 서버에 날짜형 version 디렉터리가 계속 쌓이지 않도록 보정
- `DOCS_RELEASE_ID`를 MkDocs extra 값으로 전달하되, 시작 페이지에는 날짜형 release id 대신 version, 빌드 일시, commit만 표시하도록 문서화
- Windows 로컬 검증에서도 `Asia/Seoul` timezone 처리가 가능하도록 `tzdata` 의존성 추가
- README의 자동 릴리즈/air-gapped 이미지 설명을 새 동작에 맞게 갱신

## 검증

- `scripts/resolve_docs_deploy_config.py` 로컬 실행 확인
  - `version=4.0 Diplo`
  - `release_id=4.0-Diplo-YYYYMMDD-HHmmss`
  - image tag는 release id, latest, sha tag로 생성
- `scripts/prune_docs_release_versions.py` 로컬 테스트
  - 날짜형 version 디렉터리 제거 확인
  - `versions.json`에서 날짜형 version 항목 제거 확인
- `mkdocs build --strict --clean` 성공
- 로컬 `mike deploy` 임시 브랜치 검증
  - `versions.json`에는 `4.0 Diplo`만 생성
  - `latest` alias 확인
  - 날짜형 version 디렉터리 미생성 확인
